### PR TITLE
Fix schema ID

### DIFF
--- a/json-schema/schema.json
+++ b/json-schema/schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "https://stac-extensions.github.io/template/v1.0.0/schema.json#",
+  "$id": "https://stac-extensions.github.io/version/v1.0.0/schema.json#",
   "title": "Versioning Indicators Extension",
   "description": "STAC Versioning Indicators Extension for STAC Items and STAC Collections.",
   "oneOf": [


### PR DESCRIPTION
The schema ID for the version extension references the template URI. This causes python's `jsonschema` validation to fail.